### PR TITLE
remove homepage because react doesnt like it

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,5 @@
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/icapps/react-silverback/issues"
-  },
-  "homepage": "https://github.com/icapps/react-silverback#readme"
+  }
 }


### PR DESCRIPTION
the build script from a react app uses homepage, by using it for github purposes the build was broken.